### PR TITLE
DPI-2928 Package rhtmlDonut in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "rhtmlDonut";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''R htmlwidget package for creating a detailed donut plot.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    htmlwidgets
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package rhtmlDonut in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR